### PR TITLE
Regex search and render performance

### DIFF
--- a/src/components/temList.js
+++ b/src/components/temList.js
@@ -11,7 +11,7 @@ function TemList({ tems }) {
 	)
 
 	const temList = useMemo(() => {
-		const searchRegex = new RegExp(search);
+		const searchRegex = new RegExp(search, "i");
 		let temsToShow = [];
 
 		if (!search || !search.length || !!"".match(searchRegex)) {

--- a/src/components/temList.js
+++ b/src/components/temList.js
@@ -4,30 +4,16 @@ import Weaknesses from './weaknesses';
 function TemList({ tems }) {
 
 	const [search, setSearch] = useState('');
-	
-	const checkMatch = (name, number, string) => (
-		name.toLowerCase().includes(string) ||
-		number.toString().includes(string)
-	);
+
+	const checkMatchRegex = (tem, searchRegex) => (
+		tem.name.toLowerCase().match(searchRegex) || 
+		tem.number.toString().match(searchRegex)		
+	)
 
 	const temList = useMemo(() => {
-		return tems.map((tem) => {
-			if (checkMatch(tem.name, tem.number, search.toLowerCase())) {
-				return (
-					<div className='tem-wrapper' key={tem.name}>
-						<img className='tem-portrait' src={tem.wikiPortraitUrlLarge} alt={tem.name} />
-						<div className='tem-info'>
-							<div className='tem-title'>
-								<p className='tem-number'>#{tem.number}</p>
-								<h3 className='tem-name'>{tem.name}</h3>
-							</div>
-							<Weaknesses tem={tem} />
-						</div>
-					</div>
-				)
-			}
-			else return undefined;
-			}).filter((tem) => tem !== undefined);
+		const searchRegex = new RegExp(search); // instancing before loop
+		if (!search || !search.length || !!"".match(searchRegex)) return tems;
+		return tems.filter(tem => checkMatchRegex(tem, searchRegex));
 	}, [tems, search]);
 
 	return (
@@ -39,7 +25,18 @@ function TemList({ tems }) {
 				placeholder='Search Temtem here...'
 			/>
 			<div className='tem-container'>
-				{temList}
+				{temList.map((tem) => (
+					<div className='tem-wrapper' key={tem.name}>
+						<img className='tem-portrait' src={tem.wikiPortraitUrlLarge} alt={tem.name} />
+						<div className='tem-info'>
+							<div className='tem-title'>
+								<p className='tem-number'>#{tem.number}</p>
+								<h3 className='tem-name'>{tem.name}</h3>
+							</div>
+							<Weaknesses tem={tem} />
+						</div>
+					</div>
+				))}
 				{
 					!temList.length && search?.length && (
 						<p className='tem-missing-warning'>

--- a/src/components/temList.js
+++ b/src/components/temList.js
@@ -11,9 +11,16 @@ function TemList({ tems }) {
 	)
 
 	const temList = useMemo(() => {
-		const searchRegex = new RegExp(search); // instancing before loop
-		if (!search || !search.length || !!"".match(searchRegex)) return tems;
-		return tems.filter(tem => checkMatchRegex(tem, searchRegex));
+		const searchRegex = new RegExp(search);
+		let temsToShow = [];
+
+		if (!search || !search.length || !!"".match(searchRegex)) {
+			temsToShow = tems;
+		} else {
+			temsToShow = tems.filter(tem => checkMatchRegex(tem, searchRegex));
+		}
+
+		return new Set(temsToShow.map(tem => tem.number));
 	}, [tems, search]);
 
 	return (
@@ -25,8 +32,8 @@ function TemList({ tems }) {
 				placeholder='Search Temtem here...'
 			/>
 			<div className='tem-container'>
-				{temList.map((tem) => (
-					<div className='tem-wrapper' key={tem.name}>
+				{tems.map((tem) => (
+					<div className='tem-wrapper' key={tem.name} style={{display: temList.has(tem.number) ? "inherit" : "none"}}>
 						<img className='tem-portrait' src={tem.wikiPortraitUrlLarge} alt={tem.name} />
 						<div className='tem-info'>
 							<div className='tem-title'>
@@ -38,7 +45,7 @@ function TemList({ tems }) {
 					</div>
 				))}
 				{
-					!temList.length && search?.length && (
+					!temList.size && search?.length && (
 						<p className='tem-missing-warning'>
 							<span className='tem-warning tem-tag'>⚠</span> No Temtem with that <span className='tem-tag'>name </span> or <span className='tem-tag'>number</span> found
 						</p>

--- a/src/styles/search.scss
+++ b/src/styles/search.scss
@@ -1,6 +1,6 @@
 .search {
   width: 100%;
-  margin-top: 15vh;
+  margin-top: 5vh;
   margin-bottom: 20px;
   padding: 0 18px;
   height: 40px;

--- a/src/styles/temList.scss
+++ b/src/styles/temList.scss
@@ -16,7 +16,7 @@
       gap: 20px;
       overflow-y: scroll;
       width: 100%;
-      max-height: calc(75vh - 40px);
+      max-height: calc(85vh - 40px);
 
       @include desktop {
           gap: 35px;


### PR DESCRIPTION
- Added possibility to search by regex. 
   - Useful to search multiple Tems at once. Example using the search string `gharunder|skun`: 
![image](https://user-images.githubusercontent.com/1936255/190888813-7a908d82-1815-4727-b6be-94315b644b7c.png)

- Improved list render performance.
   - The list was freezing when rendering all Tems so I did a "workaround" to avoid installing another dependency like "react-window" (it is not better doing this, it was only a preference of mine).

- Decreased top padding to use more of the screen
   